### PR TITLE
Camel-case: Add '_' to a separator list

### DIFF
--- a/GenerateIconFontCppHeaders.py
+++ b/GenerateIconFontCppHeaders.py
@@ -131,6 +131,7 @@ import yaml
 import os
 import sys
 import logging
+import re
 
 if sys.version_info[0] < 3:
     raise Exception( "Python 3 or a more recent version is required." )
@@ -643,7 +644,7 @@ class LanguageCSharp( Language ):
 
     @classmethod
     def to_camelcase( cls, text ):
-        parts = text.split( '-' )
+        parts = re.split('[-_]', text)  # Split the text using either '-' or '_' as separators
         for i in range( len( parts ) ):
             p = parts[i]
             parts[ i ] = p[ 0 ].upper() + p[ 1: ].lower()


### PR DESCRIPTION
Currently, `to_camelcase` takes into account only '-' as a separator (because of CSS' kebab-case). But there are also a lot of places where `_` is used (snake_case), it leads to inconsistent naming issues.

**Please note** that this PR introduces **breaking changes** to existing names.