### PR TITLE
Update GenerateIconFontCppHeaders.py

### DIFF
--- a/GenerateIconFontCppHeaders.py
+++ b/GenerateIconFontCppHeaders.py
@@ -456,8 +456,8 @@ class FontLC( FontKI ):               # Lucide
     font_name = 'Lucide'
     font_abbr = 'LC'
     font_data_prefix = '.icon-'
-    font_data = 'https://unpkg.com/lucide-static@latest/font/lucide.css'
-    ttfs = [[ font_abbr, 'lucide.ttf', 'https://unpkg.com/lucide-static@latest/font/lucide.ttf' ]]
+    font_data = 'https://cdn.jsdelivr.net/npm/lucide-static@latest/font/lucide.css'
+    ttfs = [[ font_abbr, 'lucide.ttf', 'https://cdn.jsdelivr.net/npm/lucide-static@latest/font/lucide.ttf' ]]
 
 
 # Languages


### PR DESCRIPTION
Lucide: switch to jsDelivr as unpkg gives read timed out error during download attempt:

```
PS D:\IconFontCppHeaders> python3.exe .\GenerateIconFontCppHeaders.py ttf2headerC = True
ERROR : HTTPSConnectionPool(host='unpkg.com', port=443): Read timed out. (read timeout=2)
```